### PR TITLE
Fix scrolling unsynced behavior between backdrop and textarea

### DIFF
--- a/react-highlight-within-textarea/src/styles/styles.css
+++ b/react-highlight-within-textarea/src/styles/styles.css
@@ -40,6 +40,7 @@
 .content {
 	border: 1px solid;
 	background: none transparent !important;
+  pointer-events: none;
 }
 
 .content mark {


### PR DESCRIPTION
Since textarea and div with marks overlap each other, sometimes focus could be on one or another. When focus is no textarea and it is scrolled, we programatically scroll backdrop div with marks by `handleScroll` method. However, when backdrop is in focus and scrolled, we don't do vice versa, so backdrop with marks is scrolled, while textearea stays unscrolled, so they misaligned. The easiest way to handle it is to add `pointer-events: none;` to backdrop styles, so it skips all clicks\scrolls and other events and becomes "invisible" allowing textarea to catch it and call same `handleScroll`